### PR TITLE
Add PEDP open source guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,2 +1,1 @@
 Our Code of Conduct can be found [here](https://github.com/Public-Environmental-Data-Partners/overview/blob/main/CODE_OF_CONDUCT.md).
-

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,2 @@
+Our Code of Conduct can be found [here](https://github.com/Public-Environmental-Data-Partners/overview/blob/main/CODE_OF_CONDUCT.md).
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,9 @@
-# Contributing to `downlow`
+# Contributing Guidelines
+
+We love improvements to our tools! PEDP has general [guidelines for contributing](https://github.com/Public-Environmental-Data-Partners/overview/blob/main/CONTRIBUTING.md) and a [code of conduct](https://github.com/Public-Environmental-Data-Partners/overview/blob/main/CODE_OF_CONDUCT.md) for all of our organizational repos.
+
+
+# Here are some notes specific to downlow
 
 Contributions are welcome, and they are greatly appreciated!
 Every little bit helps, and credit will always be given.
@@ -9,7 +14,7 @@ You can contribute in many ways:
 
 ## Report Bugs
 
-Report bugs at https://github.com/willf/downlow/issues
+Report bugs at https://github.com/Public-Environmental-Data-Partners/downlow/issues
 
 If you are reporting a bug, please include:
 
@@ -33,7 +38,7 @@ downlow could always use more documentation, whether as part of the official doc
 
 ## Submit Feedback
 
-The best way to send feedback is to file an issue at https://github.com/willf/downlow/issues.
+The best way to send feedback is to file an issue at https://github.com/Public-Environmental-Data-Partners/downlow/issues.
 
 If you are proposing a new feature:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,6 @@
 
 We love improvements to our tools! PEDP has general [guidelines for contributing](https://github.com/Public-Environmental-Data-Partners/overview/blob/main/CONTRIBUTING.md) and a [code of conduct](https://github.com/Public-Environmental-Data-Partners/overview/blob/main/CODE_OF_CONDUCT.md) for all of our organizational repos.
 
-
 # Here are some notes specific to downlow
 
 Contributions are welcome, and they are greatly appreciated!

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # downlow: A bulk downloader with tenacity and grace
 
-[![Build status](https://img.shields.io/github/actions/workflow/status/willf/downlow/main.yml?branch=main)](https://github.com/willf/downlow/actions/workflows/main.yml?query=branch%3Amain)
-[![Commit activity](https://img.shields.io/github/commit-activity/m/willf/downlow)](https://img.shields.io/github/commit-activity/m/willf/downlow)
-[![License](https://img.shields.io/github/license/willf/downlow)](https://img.shields.io/github/license/willf/downlow)
+[![Build status](https://img.shields.io/github/actions/workflow/status/Public-Environmental-Data-Partners/downlow/main.yml?branch=main)](https://github.com/Public-Environmental-Data-Partners/downlow/actions/workflows/main.yml?query=branch%3Amain)
+[![Commit activity](https://img.shields.io/github/commit-activity/m/Public-Environmental-Data-Partners/downlow)](https://img.shields.io/github/commit-activity/m/Public-Environmental-Data-Partners/downlow)
+[![License](https://img.shields.io/github/license/Public-Environmental-Data-Partners/downlow)](https://img.shields.io/github/license/Public-Environmental-Data-Partners/downlow)
 
 A bulk downloader with tenacity and grace
 
-- **Github repository**: <https://github.com/willf/downlow/>
+- **Github repository**: <https://github.com/Public-Environmental-Data-Partners/downlow/>
 - **Documentation** <https://pypi.org/project/downlow/>
 
 Attempt to bulk download a list of URLs with some tenacity, but also


### PR DESCRIPTION
This PR does three things:

1. Adds the default Code of Conduct file
2. Updates the Contributing file with the default language for PEDP at the top, leaving the downlow specific notes in place below
3. Updates the README to use the new repo link (https://github.com/Public-Environmental-Data-Partners/downlow) instead of the old one (https://github.com/willf/downlow)
